### PR TITLE
Add limit functionality to bitbucket tables. Closes #57

### DIFF
--- a/bitbucket/table_bitbucket_branch_restriction.go
+++ b/bitbucket/table_bitbucket_branch_restriction.go
@@ -135,6 +135,11 @@ func tableBitbucketBranchRestrictionsList(ctx context.Context, d *plugin.QueryDa
 
 	for _, branchRestriction := range branchRestrictionList.BranchRestrictions {
 		d.StreamListItem(ctx, branchRestriction)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil

--- a/bitbucket/table_bitbucket_commit.go
+++ b/bitbucket/table_bitbucket_commit.go
@@ -153,6 +153,11 @@ func tableBitbucketCommitsList(ctx context.Context, d *plugin.QueryData, _ *plug
 
 	for _, commit := range commitList.Commits {
 		d.StreamListItem(ctx, commit)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil

--- a/bitbucket/table_bitbucket_issue.go
+++ b/bitbucket/table_bitbucket_issue.go
@@ -180,6 +180,11 @@ func tableBitbucketIssuesList(ctx context.Context, d *plugin.QueryData, _ *plugi
 
 	for _, issue := range issueList.Issues {
 		d.StreamListItem(ctx, issue)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil

--- a/bitbucket/table_bitbucket_my_project.go
+++ b/bitbucket/table_bitbucket_my_project.go
@@ -131,6 +131,11 @@ func tableBitbucketMyProjectList(ctx context.Context, d *plugin.QueryData, h *pl
 
 		for _, project := range projectList.Projects {
 			d.StreamListItem(ctx, project)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 
 		if projectList.Next == "" {

--- a/bitbucket/table_bitbucket_my_repository.go
+++ b/bitbucket/table_bitbucket_my_repository.go
@@ -33,6 +33,11 @@ func tableBitbucketMyRepositoryList(ctx context.Context, d *plugin.QueryData, h 
 
 	for _, repo := range repos.Items {
 		d.StreamListItem(ctx, repo)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil

--- a/bitbucket/table_bitbucket_my_workspace.go
+++ b/bitbucket/table_bitbucket_my_workspace.go
@@ -66,6 +66,11 @@ func tableBitbucketMyWorkspaceList(ctx context.Context, d *plugin.QueryData, _ *
 
 	for _, workspace := range resp.Workspaces {
 		d.StreamListItem(ctx, workspace)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil

--- a/bitbucket/table_bitbucket_project.go
+++ b/bitbucket/table_bitbucket_project.go
@@ -50,6 +50,11 @@ func tableBitbucketProjectList(ctx context.Context, d *plugin.QueryData, h *plug
 
 		for _, project := range projectList.Projects {
 			d.StreamListItem(ctx, project)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 
 		if projectList.Next == "" {

--- a/bitbucket/table_bitbucket_pull_request.go
+++ b/bitbucket/table_bitbucket_pull_request.go
@@ -186,6 +186,11 @@ func tableBitbucketPullRequestList(ctx context.Context, d *plugin.QueryData, _ *
 
 	for _, issue := range pullRequestList.PullRequests {
 		d.StreamListItem(ctx, issue)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil

--- a/bitbucket/table_bitbucket_workspace_member.go
+++ b/bitbucket/table_bitbucket_workspace_member.go
@@ -95,6 +95,11 @@ func tableBitbucketWorkspaceMemberList(ctx context.Context, d *plugin.QueryData,
 
 	for _, item := range memberList.Members {
 		d.StreamListItem(ctx, item)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  repository_full_name,
  default_merge_strategy,
  type
from
  bitbucket_branch
where
  repository_full_name = 'souravthe/test1' limit 3
+--------+----------------------+------------------------+--------+
| name   | repository_full_name | default_merge_strategy | type   |
+--------+----------------------+------------------------+--------+
| test11 | souravthe/test1      | merge_commit           | branch |
| test10 | souravthe/test1      | merge_commit           | branch |
| test12 | souravthe/test1      | merge_commit           | branch |
+--------+----------------------+------------------------+--------+

> select * from bitbucket_workspace_member where workspace_slug = 'souravthe'
+--------------------+----------------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------+-------------+------
| display_name       | uuid                                   | account_id               | self_link                                                                                             | member_type | works
+--------------------+----------------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------+-------------+------
| Sourav Chakraborty | {f49e339b-2e19-430c-93f9-7c9131cc351b} | 60e6b6f10dd4f60076af9b2e | https://api.bitbucket.org/2.0/workspaces/souravthe/members/%7Bf49e339b-2e19-430c-93f9-7c9131cc351b%7D | user        | soura
+--------------------+----------------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------+-------------+------


> select * from bitbucket_tag where repository_full_name = 'souravthe/test1'
+------+----------------------+-----------+------+--------+-------+-------+------+
| name | repository_full_name | self_link | type | target | heads | title | _ctx |
+------+----------------------+-----------+------+--------+-------+-------+------+
+------+----------------------+-----------+------+--------+-------+-------+------+


> select * from bitbucket_project where workspace_slug = 'souravthe'
+------+----------------------------------------+------+----------------+---------------------------+-------------+------------+--------------------+------------+----------------------------------------+-----------
| name | uuid                                   | key  | workspace_slug | created                   | description | is_private | owner_display_name | owner_type | owner_uuid                             | self_link 
+------+----------------------------------------+------+----------------+---------------------------+-------------+------------+--------------------+------------+----------------------------------------+-----------
| test | {505e34aa-9cde-47a4-9a62-d3579fc00bc0} | TEST | souravthe      | 2021-07-08T13:59:00+05:30 |             | false      | Sourav Chakraborty | user       | {f49e339b-2e19-430c-93f9-7c9131cc351b} | https://ap
+------+----------------------------------------+------+----------------+---------------------------+-------------+------------+--------------------+------------+----------------------------------------+-----------

> select * from bitbucket_my_repository
+-------+----------------------------------------+-------+-----------------+-------------+-------------+----------+------------+------------+--------------------------+--------------------+------------+------------
| name  | uuid                                   | slug  | full_name       | description | fork_policy | language | is_private | has_issues | owner_account_id         | owner_display_name | owner_type | owner_uuid 
+-------+----------------------------------------+-------+-----------------+-------------+-------------+----------+------------+------------+--------------------------+--------------------+------------+------------
| test1 | {de7ccc7b-70f5-48e0-bb99-94a8bf57e901} | test1 | souravthe/test1 |             |             |          | true       | false      | 60e6b6f10dd4f60076af9b2e | Sourav Chakraborty | user       | {f49e339b-2
+-------+----------------------------------------+-------+-----------------+-------------+-------------+----------+------------+------------+--------------------------+--------------------+------------+------------


> select * from bitbucket_branch_restriction where repository_full_name = 'souravthe/test1'
+----------+-----------------------------------------------------------------------------------------+----------------------+-------------------+-------------+-----------------+---------+-------------------+-------
| id       | self_link                                                                               | repository_full_name | branch_match_kind | branch_type | kind            | pattern | type              | value 
+----------+-----------------------------------------------------------------------------------------+----------------------+-------------------+-------------+-----------------+---------+-------------------+-------
| 30466446 | https://api.bitbucket.org/2.0/repositories/souravthe/test1/branch-restrictions/30466446 | souravthe/test1      | glob              |             | restrict_merges | test    | branchrestriction | <null>
| 30466447 | https://api.bitbucket.org/2.0/repositories/souravthe/test1/branch-restrictions/30466447 | souravthe/test1      | glob              |             | delete          | test    | branchrestriction | <null>
| 30466445 | https://api.bitbucket.org/2.0/repositories/souravthe/test1/branch-restrictions/30466445 | souravthe/test1      | glob              |             | push            | test    | branchrestriction | <null>
+----------+-----------------------------------------------------------------------------------------+----------------------+-------------------+-------------+-----------------+---------+-------------------+-----
```
</details>
