### PR TITLE
Add account_status, created_on, is_staff and nickname columns to bitbucket_workspace_member table

### DIFF
--- a/bitbucket/connection_config.go
+++ b/bitbucket/connection_config.go
@@ -5,7 +5,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/schema"
 )
 
-type githubConfig struct {
+type bitbucketConfig struct {
 	Username *string `cty:"username"`
 	Password *string `cty:"password"`
 	BaseUrl  *string `cty:"base_url"`
@@ -24,14 +24,14 @@ var ConfigSchema = map[string]*schema.Attribute{
 }
 
 func ConfigInstance() interface{} {
-	return &githubConfig{}
+	return &bitbucketConfig{}
 }
 
 // GetConfig :: retrieve and cast connection config from query data
-func GetConfig(connection *plugin.Connection) githubConfig {
+func GetConfig(connection *plugin.Connection) bitbucketConfig {
 	if connection == nil || connection.Config == nil {
-		return githubConfig{}
+		return bitbucketConfig{}
 	}
-	config, _ := connection.Config.(githubConfig)
+	config, _ := connection.Config.(bitbucketConfig)
 	return config
 }

--- a/bitbucket/table_bitbucket_workspace_member.go
+++ b/bitbucket/table_bitbucket_workspace_member.go
@@ -39,6 +39,30 @@ func tableBitbucketWorkspaceMember(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("User.AccountId"),
 			},
 			{
+				Name:        "account_status",
+				Description: "Status of the user.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("User.AccountStatus"),
+			},
+			{
+				Name:        "created_on",
+				Description: "Creation date of the user.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("User.CreatedOn"),
+			},
+			{
+				Name:        "is_staff",
+				Description: "Is staff user.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("User.IsStaff"),
+			},
+			{
+				Name:        "nickname",
+				Description: "Account name defined by the owner.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("User.Nickname"),
+			},
+			{
 				Name:        "self_link",
 				Description: "Self link to the member.",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
This PR adds columns to the `bitbucket_workspace_member` table that I've been using for several months, and just figured I never contributed back.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
